### PR TITLE
Fix: Errno::EACCES: Permission denied @ fptr_finalize (in Windows)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,6 @@ build_script:
   - bundle update
   - bundle install
 test_script:
-  - bundle exec rake --quiet
+  - bundle exec rake test --quiet
 cache:
   - vendor/bundle


### PR DESCRIPTION
in short: Windows have different file locking mechanism and send exceptions where you didn’t expect